### PR TITLE
[PATCH] pinctrl: mediatek: remove unused drv_offset field

### DIFF
--- a/drivers/pinctrl/mediatek/pinctrl-mt8365.c
+++ b/drivers/pinctrl/mediatek/pinctrl-mt8365.c
@@ -456,7 +456,6 @@ static const struct mtk_pinctrl_devdata mt8365_pinctrl_data = {
 	.smt_offset = 0x0470,
 	.pullen_offset = 0x0860,
 	.pullsel_offset = 0x0900,
-	.drv_offset = 0x0710,
 	.type1_start = 145,
 	.type1_end = 145,
 	.port_shf = 4,

--- a/drivers/pinctrl/mediatek/pinctrl-mtk-common.h
+++ b/drivers/pinctrl/mediatek/pinctrl-mtk-common.h
@@ -263,7 +263,6 @@ struct mtk_pinctrl_devdata {
 	unsigned int smt_offset;
 	unsigned int pullen_offset;
 	unsigned int pullsel_offset;
-	unsigned int drv_offset;
 	unsigned int dout_offset;
 	unsigned int din_offset;
 	unsigned int pinmux_offset;


### PR DESCRIPTION
cherry-picked into `dev/v6.16/mt6589-pinctrl`. [af629ef](https://github.com/TeamYogaBlade2/linux/commit/af629efb66e13de102fa4c4bc0f637659a690ff5)

- https://lists.infradead.org/pipermail/linux-mediatek/2026-January/102827.html
- https://lore.kernel.org/linux-gpio/CAD++jLnG-GGxmGMmojYwSE4T3F1NjCDY-f0+CFC_Fi5gMA9v6A@mail.gmail.com/T/#t
- https://github.com/torvalds/linux/commit/ca3299dc3d6d9791c7e4a9bb7474150e66a525fe
